### PR TITLE
disallow @everyone and @roles

### DIFF
--- a/bot/setup/init.py
+++ b/bot/setup/init.py
@@ -24,6 +24,7 @@ intents = discord.Intents.all()
 client = commands.Bot(
     command_prefix=commands.when_mentioned_or("/"),
     intents=intents,
+    allowed_mentions=discord.AllowedMentions(roles=False, everyone=False),
     )
 
 import uberduck


### PR DESCRIPTION
hello,
this commit should prevent users from tricking the bot into pinging everyone, it applies to every context and message the bot sends.

![image](https://github.com/riverscuomo/cuomputer/assets/47057465/94a3611c-72a2-432b-9f8a-eaf1a4e2117b)