### PR TITLE
make weezerpedia api queries follow redirects + search titles 

### DIFF
--- a/bot/on_message/bots/weezerpedia.py
+++ b/bot/on_message/bots/weezerpedia.py
@@ -26,7 +26,7 @@ class WeezerpediaAPI:
             "format": "json",
             "list": "search",
             "srsearch": search_query,
-            "srwhat": "text",  # Could also try "title" or "nearmatch"
+            "srwhat": "nearmatch",  # Could also try "title" or "nearmatch"
             "srlimit": 1,
             "srprop": "snippet|titlesnippet|redirecttitle"
         }
@@ -47,7 +47,8 @@ class WeezerpediaAPI:
             "format": "json",
             "titles": title,
             "prop": "revisions",
-            "rvprop": "content"
+            "rvprop": "content",
+            "redirects": ""
         }
         response_full = requests.get(self.base_url, params=params_full)
         if response_full.status_code == 200:


### PR DESCRIPTION
Hi Rivers,

I tried to update the consistency of the search results hen using the `weezerpedia` command, these small changes consist of telling the MediaWiki API to follow page redirections (searching for 'album 20' should now automatically fetch the 'weezer's twentieth album' page instead) and update the search mode from 'text' to 'nearmatch' as it returned more relevant results and is the 'official' search mode used on all wikis search bars.

Here are a few examples of unexpected search results I found on the discord:
| Search term              | Result (before)                   | Result (with changes)    |
|--------------------------|-----------------------------------|--------------------------|
| blue album               | The Blue Album recording sessions | Weezer (The Blue Album)  |
| weezer's twentieth album | The Glue People                   | Weezer's twentieth album |
| Waiting on You           | Head On / Head Out                | Waiting on You           |
| only in dreams           | Karl's Corner 2011/02/22          | Only in Dreams           |

I hope this helps!