### PR TITLE
Convert internal wiki links to Markdown links (and introduce unit tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ pip install -r requirements.txt
 
 ```bash
 PYTHONPATH=%cd%
-
-```bash
+```
 
 ### Set environment variables in both a .env file and in HEROKU
 
@@ -82,6 +81,14 @@ This is probably just for me.
 heroku login
 `git push heroku main`
 one time I had to add `-f`
+
+## Unit Tests
+Unit tests can be found in the folder `tests/unit_tests`, and they can be executed with the following command (from the repository root directory):
+```bash
+PYTHONPATH=. pytest tests/unit_tests
+```
+
+If you do not have `pytest` installed, refer to https://docs.pytest.org/en/stable/getting-started.html
 
 ## Contribute
 

--- a/bot/on_message/bots/infobox_generator.py
+++ b/bot/on_message/bots/infobox_generator.py
@@ -38,6 +38,11 @@ class InfoboxGenerator:
     }
 
     def __init__(self, full_content, weezerpedia_api):
+        # Convert [[Link]] to just the text if no pipe exists, otherwise keep the link format
+        # Example: [[Pat Wilson]] becomes Pat Wilson, but [[Blue Album|the Blue Album]] becomes the Blue Album
+        full_content = re.sub(r"\[\[(.+?)(?:\|(.+?))?\]\]",
+                              lambda m: m.group(2) if m.group(2) else m.group(1), full_content)
+
         infobox_data, infobox_type = self.extract_template_data(
             full_content, 'Infobox')
 

--- a/bot/on_message/bots/weezerpedia.py
+++ b/bot/on_message/bots/weezerpedia.py
@@ -159,11 +159,6 @@ class WeezerpediaAPI:
         full_content = self.fetch_page_content(title)
         print(full_content)
 
-        # Convert [[Link]] to just the text if no pipe exists, otherwise keep the link format
-        # Example: [[Pat Wilson]] becomes Pat Wilson, but [[Blue Album|the Blue Album]] becomes the Blue Album
-        full_content = re.sub(r"\[\[(.+?)(?:\|(.+?))?\]\]",
-        lambda m: m.group(2) if m.group(2) else m.group(1), full_content)
-
         # Generate infobox
         img_file = None
         infobox_match = re.search('{{Infobox', full_content)

--- a/bot/scripts/wiki_to_markdown.py
+++ b/bot/scripts/wiki_to_markdown.py
@@ -1,7 +1,8 @@
 import re
+import urllib.parse
 
 
-def wiki_to_markdown(text):
+def wiki_to_markdown(text, wiki_url_prefix='https://www.weezerpedia.com/wiki/'):
 
     # Remove everything from "See also" or "References" downward
     text = re.split(r"==See also==", text)[0]
@@ -20,6 +21,12 @@ def wiki_to_markdown(text):
     # Convert ==Header== to # Header for Markdown headers (support multiple levels)
     text = re.sub(r"={2,}(.*?)={2,}", lambda m: "#" * (7 -
                   m.group(0).count("=")) + " " + m.group(1).strip(), text)
+
+    # Convert internal wiki links to Markdown links, using `wiki_url_prefix` as the URL prefix.
+    # Example #1: [[Pat Wilson]] becomes [Pat Wilson](https://www.weezerpedia.com/wiki/Pat Wilson);
+    # Example #2: [[Blue Album|the Blue Album]] becomes [the Blue Album](https://www.weezerpedia.com/wiki/Blue Album)
+    text = re.sub(r"\[\[(.+?)(?:\|(.+?))?\]\]",
+                  lambda m: build_md_link(m.group(2) if m.group(2) else m.group(1), m.group(1), wiki_url_prefix), text)
 
     # Convert [https://example.com description] to [description](https://example.com) for Markdown links
     text = re.sub(r"\[(https?://[^\s]+)\s(.+?)\]", r"[\2](\1)", text)
@@ -44,3 +51,8 @@ def wiki_to_markdown(text):
     text = text.strip()
 
     return text
+
+
+def build_md_link(label, path, url_prefix):
+    url = urllib.parse.quote(f"{url_prefix}{path.strip()}", safe=":/")
+    return f"[{label.strip()}]({url})"

--- a/tests/unit_tests/test_wiki_to_markdown.py
+++ b/tests/unit_tests/test_wiki_to_markdown.py
@@ -1,0 +1,8 @@
+from bot.scripts.wiki_to_markdown import wiki_to_markdown
+
+
+def test_internal_wiki_link_only_label():
+    assert wiki_to_markdown('[[Ecce Homo]]') == '[Ecce Homo](https://www.weezerpedia.com/wiki/Ecce%20Homo)'
+
+def test_internal_wiki_link_with_label_and_path():
+    assert wiki_to_markdown('[[Blue Album|the Blue Album]]') == '[the Blue Album](https://www.weezerpedia.com/wiki/Blue%20Album)'


### PR DESCRIPTION
In this small PR, I am proposing to convert internal wiki links into Markdown links, similarly to what the bot already does for external links. Feel free to discard it if you did not intend to have this feature at all.

Examples:

* `[[Ecce Homo]]` ---> `[Ecce Homo](https://www.weezerpedia.com/wiki/Ecce Homo)` (instead of the current "Ecce Homo").
* `[[Blue Album|the Blue Album]]` ---> `[the Blue Album](https://www.weezerpedia.com/wiki/Blue Album)` (instead of the current "the Blue Album").

Besides that, I am introducing some initial unit tests to the repository. Unit tests are a useful (and often cheap to write/execute) guardrail to ensure that the modules keep working as expected, without heavily relying on manual testing. I added a section in the README to explain how to run them via `pytest`. Future test suites can be added to the `tests/unit_tests` directory.

Finally, I did a small correction in the README Markdown as rendering was breaking before the *"Set environment variables"* section.

---

Sample output (for the [Bokkus](https://www.weezerpedia.com/wiki/Bokkus) wiki page):
```
**Bokkus** is a character created by [Pat Wilson](https://www.weezerpedia.com/wiki/Pat%20Wilson) and drawn on the bass drumhead of the drum set that appeared in the garage photo on the inside of the *[Blue Album](https://www.weezerpedia.com/wiki/Blue%20Album)*.  
### Origins
In 1992-1993 the band had a Marvel Comics try-out book, where you finish the comic book. Instead of doing it correctly, they went off the rails and abandoned the Spider-Man plot all-together in favor of their own story called Space Violators.  The very first appearance of Bokkus depicts him as a crazed alien who comes to Middle America to create havoc and "chase the farmer's daughter."

Pat originally drew the "Bokkus" character on the backside of a drum head while recording the Blue Album at Electric Lady Studios, where it hung on the studio wall as decoration. Later, when he decided to use the head, he traced Bokkus onto the outside of the head, only to discover that the hole cut to accommodate microphones is right where Bokkus' pipe was, so the pipe is squashed below the hole. This led to people thinking Bokkus is blowing a big bubble out of his pipe.

After some touring the head was cut out and saved by [Karl Koch](https://www.weezerpedia.com/wiki/Karl%20Koch).  He then used the original head to trace a copy on paper which was used to recreate several new Bokkus heads for use on the Memories Tour.

Bokkus appeared as a character in the visualizers utilized throughout the [Voyage to the Blue Planet](https://www.weezerpedia.com/wiki/Voyage%20to%20the%20Blue%20Planet) tour in [2024](https://www.weezerpedia.com/wiki/2024). A Bokkus enamel pin was also included in the 30th anniversary boxset edition of the *Blue*.["30th Anniversary of the Blue Album - Box Sets, Tour & More!"](https://weezer.com/news/2024/9/4/30th-anniversary-of-the-blue-album-box-sets-tour-amp-more)
```