### PR TITLE
bug fixes

### DIFF
--- a/bot/slash_commands/commands.py
+++ b/bot/slash_commands/commands.py
@@ -9,13 +9,9 @@ from bot.setup.bots import weezerpedia_api, riverpedia_api, openai_bot
 print('commands.py')
 
 SUMMARIZE_SYSTEM_PROMPT = "You are the person responsible for summarizing server messages in a succinct and effective way for the server owner and supporters. Always report the number of messages found."
-SUMMARIZE_SYSTEM_PROMPT = ""
 SUMMARIZE_USER_PROMPT = "[INTERNAL] Summarize these recent messages in channel history if theres at least one message. Close by reporting the number of messages found."
-SUMMARIZE_USER_PROMPT = SUMMARIZE_USER_PROMPT[11:]
 ADVISE_SYSTEM_PROMPT = "You are Rivers Cuomo's personal advisor who is very capable and results oriented."
-ADVISE_SYSTEM_PROMPT = ""
 ADVISE_USER_PROMPT = "[INTERNAL] Rivers Cuomo runs this Discord server. Given there is at least one message in this channel, then based on these recent messages, how would you advise him?"
-ADVISE_SYSTEM_PROMPT = ADVISE_USER_PROMPT[11:]
 
 
 def is_supporter():
@@ -65,7 +61,7 @@ async def summarize(interaction: discord.Interaction, count: int = DEFAULT_MESSA
     prompt_params = PromptParams(
         system_prompt=SUMMARIZE_SYSTEM_PROMPT,
         user_prompt=SUMMARIZE_USER_PROMPT,
-        nick=interaction.user.global_name,
+        user_name=interaction.user.global_name,
         channel_id=interaction.channel_id,
         attachment_urls=[])
     response = openai_bot.fetch_openai_completion(prompt_params, count).strip()
@@ -80,7 +76,7 @@ async def summarize_and_advise(interaction: discord.Interaction, count: int = DE
     await interaction.response.send_message("Processing...", ephemeral=True)
     prompt_params = PromptParams(system_prompt=SUMMARIZE_SYSTEM_PROMPT,
                                  user_prompt=SUMMARIZE_USER_PROMPT,
-                                 nick=interaction.user.global_name,
+                                 user_name=interaction.user.global_name,
                                  channel_id=interaction.channel_id,
                                  attachment_urls=[])
     response = openai_bot.fetch_openai_completion(prompt_params, count).strip()
@@ -92,7 +88,7 @@ async def summarize_and_advise(interaction: discord.Interaction, count: int = DE
 
     prompt_params = PromptParams(system_prompt=ADVISE_SYSTEM_PROMPT,
                                  user_prompt=ADVISE_USER_PROMPT,
-                                 nick=interaction.user.global_name,
+                                 user_name=interaction.user.global_name,
                                  channel_id=interaction.channel_id,
                                  attachment_urls=[])
     response = openai_bot.fetch_openai_completion(prompt_params,


### PR DESCRIPTION
- system messages were not getting filtered out of gpt prompt
- rivers system message was getting pre-pended to prompt BEFORE the message lookback logic, causing it to go away after the message lookback count filter
- attachment was being passed to prompt instead of the attachment url string
- message.author.nick was returning None to the prompt when a nick was not available; now it returns to display name if its not

I also added back the summarize system prompts and [INTERNAL] filtering logic for user prompts. The reason i added it is to avoid polluting the gpt prompt with the summary user prompts. See example below of what i mean, and the type of response that would come from having those. I assume you took them out to try to debug the first two issues above, but if not, feel free to add back your change.