### PR TITLE
remove internal messages from new content to avoid persisting the mandate to count messages

### DIFF
--- a/bot/on_message/bots/openai_bot.py
+++ b/bot/on_message/bots/openai_bot.py
@@ -191,7 +191,7 @@ class OpenAIBot:
 
         # Remove any existing system messages
         new_content = [
-            msg for msg in messages_in_this_channel if msg["role"] != "system"]
+            msg for msg in messages_in_this_channel if msg["role"] != "system" and "[INTERNAL]" not in msg["content"]]
 
         # Replace the channel messages with the cleaned up content
         self.openai_sessions[prompt_params.channel_id] = new_content

--- a/bot/slash_commands/commands.py
+++ b/bot/slash_commands/commands.py
@@ -9,13 +9,9 @@ from bot.setup.bots import weezerpedia_api, riverpedia_api, openai_bot
 print('commands.py')
 
 SUMMARIZE_SYSTEM_PROMPT = "You are the person responsible for summarizing server messages in a succinct and effective way for the server owner and supporters. Always report the number of messages found."
-SUMMARIZE_SYSTEM_PROMPT = ""
 SUMMARIZE_USER_PROMPT = "[INTERNAL] Summarize these recent messages in channel history if theres at least one message. Close by reporting the number of messages found."
-SUMMARIZE_USER_PROMPT = SUMMARIZE_USER_PROMPT[11:]
 ADVISE_SYSTEM_PROMPT = "You are Rivers Cuomo's personal advisor who is very capable and results oriented."
-ADVISE_SYSTEM_PROMPT = ""
 ADVISE_USER_PROMPT = "[INTERNAL] Rivers Cuomo runs this Discord server. Given there is at least one message in this channel, then based on these recent messages, how would you advise him?"
-ADVISE_SYSTEM_PROMPT = ADVISE_USER_PROMPT[11:]
 
 
 def is_supporter():


### PR DESCRIPTION
addresses https://github.com/riverscuomo/cuomputer/issues/43

as part of rivers' testing the summarize command, he removed the [INTERNAL] tag on the user prompt of the summarize message. this ends up persisting the mandate to report number of messages found in subsequent calls to the bot. i found that even just putting back the [INTERNAL] flag was enough to fix the problem as the gpt was smart enough to ignore the command in [INTERNAL]. but here i am explicitly filtering out [INTERNAL] user prompts anyway.

pls lmk if there was a specific reason to remove the [INTERNAL] tag which i am not considering here.