### PR TITLE
primitive implementation of rctalk

### DIFF
--- a/bot/on_message/bots/openai_bot.py
+++ b/bot/on_message/bots/openai_bot.py
@@ -124,7 +124,7 @@ class OpenAIBot:
 
             with contextlib.suppress(Exception):
                 print('sending response: ', reply)
-                if message.channel.id == channels["rctalk"]:
+                if (message.channel.id == channels["rctalk"]) and (message.die_roll > .9):
                     await use_voice(message, reply)
                 else:
                     await message.channel.send(reply)

--- a/bot/on_message/bots/openai_bot.py
+++ b/bot/on_message/bots/openai_bot.py
@@ -16,7 +16,7 @@ import random
 DEFAULT_MESSAGE_LOOKBACK_COUNT = 15
 DEFAULT_MAX_TOKENS = 100
 
-async def use_voice(message, reply: str):
+async def reply_with_voice(message, reply: str):
 
     if message.author.voice:
         channel = message.author.voice.channel
@@ -37,7 +37,6 @@ async def use_voice(message, reply: str):
         )):
             f.write(chunk)
 
-    print(audio_file)
     if not vc.is_playing():
         vc.play(discord.FFmpegPCMAudio(audio_file))
 
@@ -125,7 +124,7 @@ class OpenAIBot:
             with contextlib.suppress(Exception):
                 print('sending response: ', reply)
                 if (message.channel.id == channels["rctalk"]) and (message.die_roll > .9):
-                    await use_voice(message, reply)
+                    await reply_with_voice(message, reply)
                 else:
                     await message.channel.send(reply)
 

--- a/bot/on_message/bots/openai_bot.py
+++ b/bot/on_message/bots/openai_bot.py
@@ -1,10 +1,14 @@
 import contextlib
+from config import channels
 from dataclasses import dataclass
+import discord
 from discord.channel import DMChannel, PartialMessageable, StageChannel, TextChannel, Thread, VoiceChannel
 import json
 from typing import Any, Optional, Union
 import openai
+import os
 from bot.on_message.bots.weezerpedia import WeezerpediaAPI
+from fish_audio_sdk import Session, TTSRequest, ReferenceAudio
 
 from rich import print
 import random
@@ -12,6 +16,30 @@ import random
 DEFAULT_MESSAGE_LOOKBACK_COUNT = 15
 DEFAULT_MAX_TOKENS = 100
 
+async def use_voice(message, reply: str):
+
+    if message.author.voice:
+        channel = message.author.voice.channel
+
+        if message.guild.voice_client:
+            vc = message.guild.voice_client
+            if vc.channel != channel:
+                await vc.move_to(channel)
+        else:
+            vc = await channel.connect()
+
+    audio_file = f"{os.getcwd()}\\voice_output.mp3"
+    session = Session("19c527e3fe494f768815ee30ee576376")
+    with open(audio_file, "wb") as f:
+        for chunk in session.tts(TTSRequest(
+            reference_id="7ade82c5f92d47a6acf52e38613be86f",
+            text=reply
+        )):
+            f.write(chunk)
+
+    print(audio_file)
+    if not vc.is_playing():
+        vc.play(discord.FFmpegPCMAudio(audio_file))
 
 @dataclass(frozen=True)
 class PromptParams:
@@ -96,7 +124,10 @@ class OpenAIBot:
 
             with contextlib.suppress(Exception):
                 print('sending response: ', reply)
-                await message.channel.send(reply)
+                if message.channel.id == channels["rctalk"]:
+                    await use_voice(message, reply)
+                else:
+                    await message.channel.send(reply)
 
         return True
 

--- a/bot/on_message/bots/openai_bot.py
+++ b/bot/on_message/bots/openai_bot.py
@@ -28,7 +28,7 @@ async def reply_with_voice(message, reply: str):
         else:
             vc = await channel.connect()
 
-    audio_file = f"{os.getcwd()}\\voice_output.mp3"
+    audio_file = f"{os.getcwd()}/voice_output.mp3"
     session = Session("19c527e3fe494f768815ee30ee576376")
     with open(audio_file, "wb") as f:
         for chunk in session.tts(TTSRequest(

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ Deprecated==1.2.13
 discord.py==2.4.0
 et-xmlfile==1.1.0
 firebase-admin==5.1.0
+fish-audio-sdk=2024.12.5
 Flask==1.1.2
 Flask-Caching==1.9.0
 Flask-Cors==3.0.10
@@ -52,6 +53,7 @@ hpack==3.0.0
 hstspreload==2021.10.1
 httpcore==1.0.1
 httplib2==0.19.1
+httpx=0.27.2
 hyperframe==5.2.0
 idna==2.10
 itsdangerous==2.0.1


### PR DESCRIPTION
I thought it would be a cool idea to have a voice channel that speaks out the openAI responses with rivers' voice.
Near the end of this project I realized it was already attempted in RC-talk two years ago.
Interested to know why you ditched the idea. The tech is probably a lot better now.

Some things to note:
- It's the same thing as any other response, except if prompt came from rc-talk channel, it will respond via voice in that channel.
- It requires a couple packages installed per the requirements.txt
- The voice is not great; I can improve it a lot more with a quick approval on ElevenLabs; already have the training data uploaded
- Need to add ffmpeg to your Heroku build, per instructions below

![image](https://github.com/user-attachments/assets/e5f46054-28ab-4649-876d-98a11a7b2157)