### PR TITLE
edit README, and edit bot DM to unconnected users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-Certainly! Below is the updated **README** with a greatly simplified **Python Virtual Environment** section. Instead of detailed instructions, it now provides a brief overview and directs users to an external guide for comprehensive steps. Additionally, all Heroku-related sections remain moved to the end under the **Owner Setup** section, as per your previous requests.
-
----
-
 # Cuomputer ![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)
 
 The bot for my Discord server.  
@@ -279,4 +275,3 @@ This project is configured to automatically deploy to Heroku when you push to th
 5. **Enhanced Clarity and Organization:**
    - Clear section headings and concise instructions improve readability and usability for contributors.
 
-If you need any further adjustments or additional sections, feel free to let me know!

--- a/bot/scripts/assert_old_users_have_connected.py
+++ b/bot/scripts/assert_old_users_have_connected.py
@@ -24,7 +24,7 @@ async def assert_old_users_have_connected(
         await message.delete()
         await channel.send(
             """It looks like your discord account is not connected to your riverscuomo.com account. 
-           The easiest way to fix this is to follow the instructions in the #connect-to-mrn channel in the WELCOME section or in this doc https://docs.google.com/document/d/1sn8xZ9pEMEAia9jHeaC_DEKVlgCxZ6WnuPiKuI8h_cU. 
+           The easiest way to fix this is to follow the instructions in the #connect-to-mrn channel description or in this doc https://docs.google.com/document/d/1sn8xZ9pEMEAia9jHeaC_DEKVlgCxZ6WnuPiKuI8h_cU. 
           """
         )
         return False


### PR DESCRIPTION
This PR makes minor refinements to improve clarity and user experience.

Changes: 
1. Tidied up the README by removing an introductory section and ending section that seemed intended for internal discussion rather than end-user documentation.
2. Updated the bot's message for users not connected to mrn (see justification below). I didn’t perform any local tests for this contribution, because no functionality is affected, only the bot’s message content has been revised.

Justification:
This user had some issues connecting and posted this:

![image2](https://github.com/user-attachments/assets/b654492f-3ca1-4f3d-b1a0-31e13e60eda4)

Likely referring to this bot's message:

![image1](https://github.com/user-attachments/assets/144a7d87-1ccc-46e0-bcf8-d4f5e48c8d48)

My interpretation, having verified contents of channels visible to unconnected users, is that the intention is for the bot to direct users to the connect-to-mrn CHANNEL DESCRIPTION -screenshot below-  (as opposed to the "welcome section"), in addition to the Google doc.

![image0](https://github.com/user-attachments/assets/c76c4ad7-a32c-4ce6-ab75-9464ed12c820)
