### PR TITLE
Switch between waiting periods for neighbor role

### DIFF
--- a/config.py
+++ b/config.py
@@ -29,7 +29,15 @@ OAUTH2_URL = f"https://discord.com/api/oauth2/authorize?client_id={CLIENT_ID}&pe
 GENERAL_ID = 890292832198344724
 GUILD_ID = 890210072381247548
 
-neighbor_threshold = 1 * 24 * 1  # hours (2 days)
+# different possible wait periods for the neighbor role assignment
+neighbor_threshold_options = {
+    "instant":0, # no wait period
+    "delayed24": 1 * 24 * 1 # 24 hour wait period
+}
+
+# set the wait period by changing to the appropriate neighbor_threshold_options key 
+neighbor_threshold = neighbor_threshold_options["instant"] 
+
 image_threshold = 2  # user_score
 gpt_threshold = 4  # user_score
 num_roles_for_newbie = 1


### PR DESCRIPTION
This PR addresses issue #71 by introducing a dict to store different wait period keys, which can be applied to specify the neighbor_threshold. It's currently set to zero (no wait period). It should be easy to switch back to 24 hours, editing only the key assigned to neighbor_threshold (rather than editing the values themselves). It's also easy to write additional wait periods into the dict.  I've kept the equation 1*24*1 in keeping with original script (in case there was a good reason for this), although it could be simplified to "24". 

I performed a local test and the dictionary works correctly for switching between different wait periods. I couldn't test its integration with the role assignment block in the add_roles script, but the change should work because it keeps the same neighbor_threshold structure. 

Edit: markdown syntax changed the formatting of the above mentioned equation, should read 1 x 24 x 1 (but with asterisk, not x)