### PR TITLE
Update qna_default rc-talk

### DIFF
--- a/bot/on_message/bots/qna_default.py
+++ b/bot/on_message/bots/qna_default.py
@@ -9,7 +9,7 @@ async def post_qna_default_response(message):
 
     reply = [
         response,
-        "To have a fun conversation with me: please use the #coach-cuomo channel--but make sure you have the Neighbor role first.\n",
-        "To report a bug: please use the relevant channel in the Tech Support section.\n",
+        "To have a fun conversation with me: please use the #coach-cuomo channel or join the RC-talk voice channel--but make sure you have the Neighbor role first.\n",
+        "To report a bug: please use the relevant channel in the Bug Reports section.\n",
     ]
     await message.channel.send("".join(reply))


### PR DESCRIPTION
Now that the bot speaks in RC-talk, I thought this info could be added to the qna_default response. I also changed the name of where to report bugs to match Discord. No functionality changed, just message content. 