### PR TITLE
improve bot prompt to avoid starting with 'Rivers'

### DIFF
--- a/bot/on_message/bots/openai_bot.py
+++ b/bot/on_message/bots/openai_bot.py
@@ -85,7 +85,7 @@ class OpenAIBot:
         self.stimulate = " -but try to keep the conversation going. Ask questions, make suggestions, and provide information. Be engaging and stimulating."
         self.lead = " - try to subtly lead the conversation to an uncommon SPECIFIC topic that the user would find very interesting."
         self.match_tone = " - Match the style and tone of the message you are replying to."
-        self.dont_start_your_response = f" - Do not start your response with the indicator of who you are, such as '{long_name}: '. Just start with your response."
+        self.dont_start_your_response = f" - Do not start your response with '{long_name}: ' or '{short_name}: ' or any variation of your name. Always start directly with your response."
         self.always_emulate = " - Always use natural human casual speech, never robotic or formal or AI-like."
         self.laconic = " - Remember Rivers is on the laconic side, less excitable, and dry."
         self.conspiracy = " - If someone mentions the possibility that you are actually Rivers controlling the bot, rather than an AI, play along with it."


### PR DESCRIPTION
This should help the bot in RC talk avoid self identifying before responding.