### PR TITLE
prevent bot response in bug reports

### DIFF
--- a/bot/on_message/respond.py
+++ b/bot/on_message/respond.py
@@ -1,10 +1,10 @@
 import config as config
 from bot.on_message.bots.googlebot import post_google_response
 from bot.on_message.bots.qna_default import post_qna_default_response
-from bot.on_message.bots.response_handlers import CustomMessage, channels, config, handle_artists_channel, handle_coach_channel, handle_dan_channel, handle_geezerville_channel, handle_language_channels, handle_lounge_channel, handle_movies_tv_books_channel, handle_music_channel, handle_musicians_channel, handle_sarah_channel, handle_zoo_channel, openai_bot
+from bot.on_message.bots.response_handlers import CustomMessage, handle_artists_channel, handle_coach_channel, handle_dan_channel, handle_geezerville_channel, handle_language_channels, handle_lounge_channel, handle_movies_tv_books_channel, handle_music_channel, handle_musicians_channel, handle_sarah_channel, handle_zoo_channel, openai_bot
 from bot.on_message.bots.rolesbot import post_roles_response
 from bot.on_message.classes.message import CustomMessage
-from config import channels
+from config import channels, categories
 import time
 
 # dict to store last response time for rctalk
@@ -15,7 +15,7 @@ async def respond(message: CustomMessage, channel):
 
     message.log()
 
-    if channel.category_id == channels["bug_reports"]:
+    if channel.category_id == categories["bug_reports"]:
         return 
 
     if await handle_lounge_channel(message, channel):

--- a/bot/on_message/respond.py
+++ b/bot/on_message/respond.py
@@ -15,6 +15,9 @@ async def respond(message: CustomMessage, channel):
 
     message.log()
 
+    if channel.category_id == channels["bug_reports"]:
+        return 
+
     if await handle_lounge_channel(message, channel):
         return
 

--- a/config.py
+++ b/config.py
@@ -80,9 +80,11 @@ channels = {
     "lounge": 890210073308172347,
     "lounge2": 1059229073466998854,
     "jamroom": 890210073308172348,
+}
 
-    # BUG REPORTS
-    "bug_reports": 892881079424397343, # Category ID
+""" Categories """
+categories = {
+    "bug_reports": 892881079424397343,
 }
 
 # all_response_channels = []

--- a/config.py
+++ b/config.py
@@ -80,6 +80,9 @@ channels = {
     "lounge": 890210073308172347,
     "lounge2": 1059229073466998854,
     "jamroom": 890210073308172348,
+
+    # BUG REPORTS
+    "bug_reports": 892881079424397343, # Category ID
 }
 
 # all_response_channels = []


### PR DESCRIPTION
This should prevent the bot from responding in any channel with a `category_id `that matches the "Bug Reports" `CategoryID` .

It uses the category ID for the bug reports group and checks that against the category ID for channels.
