### PR TITLE
Improve wiki markdown formatting

### DIFF
--- a/tests/unit_tests/test_wiki_to_markdown.py
+++ b/tests/unit_tests/test_wiki_to_markdown.py
@@ -6,3 +6,13 @@ def test_internal_wiki_link_only_label():
 
 def test_internal_wiki_link_with_label_and_path():
     assert wiki_to_markdown('[[Blue Album|the Blue Album]]', False) == '[the Blue Album](https://www.weezerpedia.com/wiki/Blue%20Album)'
+
+
+def test_remove_numeric_footnote_markers():
+    text = "Weezer formed in 1992.[1] They released the Blue Album." 
+    assert wiki_to_markdown(text, False) == "Weezer formed in 1992. They released the Blue Album."
+
+
+def test_remove_nested_template():
+    input_text = 'Info {{cite web|url={{URL|https://example.com}}|title=Example}} end'
+    assert wiki_to_markdown(input_text, False) == 'Info  end'


### PR DESCRIPTION
### Summary
Issue: https://github.com/riverscuomo/cuomputer/issues/93
handle nested wiki templates in wiki_to_markdown
strip numeric footnote markers
add unit tests for new cleanup logic

### Testing
python3 -m pytest -q tests/unit_tests
https://chatgpt.com/codex/tasks/task_e_68421ef0a0a0832ab04ef5e09237c6c9

Have not ran the bot locally to test